### PR TITLE
Make video tags more consistent

### DIFF
--- a/static/vids.json
+++ b/static/vids.json
@@ -353,7 +353,7 @@
             "michael-munday"
         ],
         "tags": [
-            "assembly"
+            "assembler"
         ]
     },
     {
@@ -775,7 +775,7 @@
             "chang-sau-sheong"
         ],
         "tags": [
-            "web-applications"
+            "web-app"
         ]
     },
     {
@@ -979,7 +979,7 @@
         ],
         "tags": [
             "cockroachdb",
-            "scale"
+            "scalability"
         ]
     },
     {
@@ -1889,7 +1889,7 @@
             "fatih-arslan"
         ],
         "tags": [
-            "dogto",
+            "dotgo",
             "tools"
         ]
     },
@@ -2153,7 +2153,7 @@
             "ian-smith"
         ],
         "tags": [
-            "interface",
+            "interfaces",
             "seven5"
         ]
     },
@@ -2541,7 +2541,7 @@
         "tags": [
             "gophercon",
             "interfaces",
-            "net/http"
+            "net-http"
         ]
     },
     {
@@ -2580,7 +2580,7 @@
         ],
         "tags": [
             "gophercon",
-            "garbage-collector"
+            "garbage-collection"
         ]
     },
     {
@@ -2773,7 +2773,7 @@
         ],
         "tags": [
             "martini",
-            "web-frameworks"
+            "web-framework"
         ]
     },
     {
@@ -3038,7 +3038,7 @@
             "jp-robinson"
         ],
         "tags": [
-            "new-york-times"
+            "nytimes"
         ]
     },
     {
@@ -4383,7 +4383,7 @@
         ],
         "tags": [
             "dotgo",
-            "state-of-gopher"
+            "state-of-go"
         ]
     },
     {
@@ -4914,7 +4914,7 @@
             "toby-hede"
         ],
         "tags": [
-            "functional"
+            "functional-programming"
         ]
     },
     {
@@ -5648,7 +5648,7 @@
         ],
         "tags": [
             "meetup",
-            "introduction",
+            "intro",
             "intellij",
             "martini"
         ]


### PR DESCRIPTION
Fixed some typos in tags, merged non-misspelled tags for the same
subject.

If one tag had videos than a similar tag that I merged it with, I chose
the tag with the most videos. If they had an equal amount of videos,
I picked the one I liked best.