### PR TITLE
Normalize speaker name

### DIFF
--- a/static/vids.json
+++ b/static/vids.json
@@ -443,7 +443,7 @@
         "added": "2016-12-05",
         "title": "dotGo 2016 - Robert Griesemer - Prototype your design!",
         "speakers": [
-            "Robert Griesemer"
+            "robert-griesemer"
         ],
         "tags": [
             "dotgo",


### PR DESCRIPTION
Sorry that I forgot to normalize the speaker names in my dotGo 2016 pull request. Fixed the last one that you missed.